### PR TITLE
Add a logo

### DIFF
--- a/elm-graphql.svg
+++ b/elm-graphql.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1028 1028" enable-background="new 0 0 1028 1028" xml:space="preserve">
+<g>
+	<circle fill="#86C441" cx="186.8" cy="324.7" r="82.2"/>
+	<circle fill="#86C441" cx="515.7" cy="893.2" r="82.2"/>
+	<circle fill="#86C441" cx="842.2" cy="324.7" r="82.2"/>
+	<polygon fill="#86C441" points="241.1,674.1 514.7,200.1 788.4,674.1 	"/>
+	<polygon fill="#EFAD1E" points="185,324.9 186.2,674.2 485.1,153.3 	"/>
+	<polygon fill="#5B6479" points="844,326.1 842.8,675.4 543.9,154.5 	"/>
+	<polygon fill="#62B5CC" points="517.7,896.5 215.1,722.1 815.7,721.3 	"/>
+	<circle fill="#62B5CC" cx="513.3" cy="136.8" r="82.2"/>
+	<circle fill="#5B6479" cx="186.8" cy="705.3" r="82.2"/>
+	<circle fill="#EFAD1E" cx="842.2" cy="705.3" r="82.2"/>
+</g>
+</svg>


### PR DESCRIPTION
Congratulations on releasing 1.0.0! I'm very much looking forward to finding excuses to use this package.

I'd like to propose a logo. I tried very hard to work with just the shapes available in the Elm tangram, but I just couldn't make it work 😄. Here's what I came up with after some reconciliation: 

<img width="510" alt="screen shot 2017-03-20 at 13 25 14" src="https://cloud.githubusercontent.com/assets/579491/24099641/b538c8ce-0d70-11e7-83df-17a5ac88908e.png">

If the layered nodes is creating too much of a 3D effect, here's a flatter alternative I could work into this PR:

<img width="240" alt="screen shot 2017-03-20 at 13 26 29" src="https://cloud.githubusercontent.com/assets/579491/24099667/da91c788-0d70-11e7-909f-4ad7848f06cf.png">
