### PR TITLE
ListTypeRef serialization fix

### DIFF
--- a/src/GraphQL/Request/Document/AST/Serialize.elm
+++ b/src/GraphQL/Request/Document/AST/Serialize.elm
@@ -108,7 +108,7 @@ serializeCoreTypeRef coreTypeRef =
             name
 
         AST.ListTypeRef typeRef ->
-            serializeTypeRef typeRef
+            "[" ++ (serializeTypeRef typeRef) ++ "]"
 
 
 serializeValue : AST.Value variableConstraint -> String


### PR DESCRIPTION
#11 
Add brackets to ListTypeRef serialization
Tested with this example: https://runelm.io/c/sgj  (mutation will be correct after library update)

