### PR TITLE
Add query/mutation versions which returns raw `Http.Response` in Task

### DIFF
--- a/src/GraphQL/Client/Http.elm
+++ b/src/GraphQL/Client/Http.elm
@@ -5,9 +5,7 @@ module GraphQL.Client.Http
         , Error(..)
         , RequestOptions
         , sendQuery
-        , sendQueryRaw
         , sendMutation
-        , sendMutationRaw
         , customSendQuery
         , customSendQueryRaw
         , customSendMutation
@@ -62,16 +60,6 @@ sendQuery url request =
     parseResponse request <| sendQueryRaw url request
 
 
-{-| Takes a URL and a `Query` `Request` and returns a `Task` that you can perform with `Task.attempt` which will send a `POST` request to a GraphQL server at the given endpoint and return raw `Http.Response` in Task.
--}
-sendQueryRaw :
-    String
-    -> Builder.Request Builder.Query result
-    -> Task Error (Http.Response String)
-sendQueryRaw =
-    Util.defaultRequestOptions >> send
-
-
 {-| Takes a URL and a `Mutation` `Request` and returns a `Task` that you can perform with `Task.attempt` which will send a `POST` request to a GraphQL server at the given endpoint.
 -}
 sendMutation :
@@ -80,16 +68,6 @@ sendMutation :
     -> Task Error result
 sendMutation url request =
     parseResponse request <| sendMutationRaw url request
-
-
-{-| Takes a URL and a `Mutation` `Request` and returns a `Task` that you can perform with `Task.attempt` which will send a `POST` request to a GraphQL server at the given endpoint and return raw `Http.Response` in Task.
--}
-sendMutationRaw :
-    String
-    -> Builder.Request Builder.Mutation result
-    -> Task Error (Http.Response String)
-sendMutationRaw =
-    Util.defaultRequestOptions >> send
 
 
 {-| Options available for customizing GraphQL HTTP requests. `method` should be either `"GET"` or `"POST"`. For `GET` requests, the `url` is modified to include extra parameters in the query string for the GraphQL document and variables. Otherwise, the document and variables are included in the HTTP request body.

--- a/src/GraphQL/Client/Http/Util.elm
+++ b/src/GraphQL/Client/Http/Util.elm
@@ -1,10 +1,10 @@
 module GraphQL.Client.Http.Util exposing (..)
 
-import Json.Encode
-import Json.Decode
-import Http
-import Time exposing (Time)
 import GraphQL.Response as Response
+import Http
+import Json.Decode
+import Json.Encode
+import Time exposing (Time)
 
 
 postBodyJson : String -> Maybe Json.Encode.Value -> Json.Encode.Value
@@ -75,12 +75,12 @@ type Error
     | GraphQLError (List RequestError)
 
 
-type alias RequestConfig a =
+type alias RequestConfig =
     { method : String
     , headers : List Http.Header
     , url : String
     , body : Http.Body
-    , expect : Http.Expect a
+    , expect : Http.Expect (Http.Response String)
     , timeout : Maybe Time
     , withCredentials : Bool
     }
@@ -99,14 +99,10 @@ defaultRequestOptions url =
 requestConfig :
     RequestOptions
     -> String
-    -> Json.Decode.Decoder a
     -> Maybe Json.Encode.Value
-    -> RequestConfig a
-requestConfig requestOptions documentString dataDecoder variableValues =
+    -> RequestConfig
+requestConfig requestOptions documentString variableValues =
     let
-        decoder =
-            Json.Decode.field "data" dataDecoder
-
         ( url, body ) =
             if requestOptions.method == "GET" then
                 ( parameterizedUrl requestOptions.url documentString variableValues, Http.emptyBody )
@@ -117,7 +113,7 @@ requestConfig requestOptions documentString dataDecoder variableValues =
         , headers = requestOptions.headers
         , url = url
         , body = body
-        , expect = Http.expectJson decoder
+        , expect = Http.expectStringResponse (\val -> Ok val)
         , timeout = requestOptions.timeout
         , withCredentials = requestOptions.withCredentials
         }


### PR DESCRIPTION
I am just added `sendQueryRaw`, `sendMutationRaw`, `customSendQueryRaw` and `customSendMutationRaw` versions which returns raw `Http.Response`.

So it will able to deal with response headers or what more important - raw body. I am personally using it for 2 purposes: 

- LocalStorage caching. I am hashing request + variables and caching raw response body in LocalStorage. 
- Custom parsing for errors. For example when record is not found there is error with `type=NOT_FOUND` (like on GitHub GraphQL). 

Also I think it fixes https://github.com/jamesmacaulay/elm-graphql/issues/19 since user will able to use custom decoders with `oneOf`.

I am thought about modifying `RequestOptions` but it will break backwards compatibility. 