### PR TITLE
Reuse code of named{Query|Mutation}Document

### DIFF
--- a/src/GraphQL/Request/Builder.elm
+++ b/src/GraphQL/Request/Builder.elm
@@ -421,28 +421,20 @@ document operation =
 queryDocument :
     ValueSpec NonNull ObjectType result vars
     -> Document Query result vars
-queryDocument spec =
-    document
-        (Operation
-            { operationType = queryOperationType
-            , name = Nothing
-            , directives = []
-            , spec = spec
-            }
-        )
+queryDocument spec = namedQueryDocument Nothing spec
 
 
 {-| Like `queryDocument`, but takes a name for the query as an extra first argument. The name is used as a label for the operation in the generated GraphQL document and can be useful for logging and debugging purposes.
 -}
 namedQueryDocument :
-    String
+    Maybe String
     -> ValueSpec NonNull ObjectType result vars
     -> Document Query result vars
-namedQueryDocument queryName spec =
+namedQueryDocument maybeQueryName spec =
     document
         (Operation
             { operationType = queryOperationType
-            , name = Just queryName
+            , name = maybeQueryName
             , directives = []
             , spec = spec
             }
@@ -483,28 +475,20 @@ queryOperationType =
 mutationDocument :
     ValueSpec NonNull ObjectType result vars
     -> Document Mutation result vars
-mutationDocument spec =
-    document
-        (Operation
-            { operationType = mutationOperationType
-            , name = Nothing
-            , directives = []
-            , spec = spec
-            }
-        )
+mutationDocument spec = namedMutationDocument Nothing spec
 
 
 {-| Like `mutationDocument`, but takes a name for the mutation as an extra first argument. The name is used as a label for the operation in the generated GraphQL document and can be useful for logging and debugging purposes.
 -}
 namedMutationDocument :
-    String
+    Maybe String
     -> ValueSpec NonNull ObjectType result vars
     -> Document Mutation result vars
-namedMutationDocument mutationName spec =
+namedMutationDocument maybeMutationName spec =
     document
         (Operation
             { operationType = mutationOperationType
-            , name = Just mutationName
+            , name = maybeMutationName
             , directives = []
             , spec = spec
             }

--- a/tests/GraphQL/Request/BuilderTests.elm
+++ b/tests/GraphQL/Request/BuilderTests.elm
@@ -586,7 +586,7 @@ tests =
                 |> Expect.equal (Ok (Dict.fromList exampleKeyValuePairsDecoded))
     , test "named query with arguments" <|
         \() ->
-            (namedQueryDocument "MyQuery" (extract (field "foo" [ ( "bar", Var.required "bar" identity Var.bool |> Arg.variable ) ] string)))
+            (namedQueryDocument (Just "MyQuery") (extract (field "foo" [ ( "bar", Var.required "bar" identity Var.bool |> Arg.variable ) ] string)))
                 |> request True
                 |> requestBody
                 |> Expect.equal """query MyQuery ($bar: Boolean!) {
@@ -594,7 +594,7 @@ tests =
 }"""
     , test "named mutation with no arguments" <|
         \() ->
-            (namedMutationDocument "MyMutation" (extract (field "foo" [] string)))
+            (namedMutationDocument (Just "MyMutation") (extract (field "foo" [] string)))
                 |> request True
                 |> requestBody
                 |> Expect.equal """mutation MyMutation {


### PR DESCRIPTION
This is more of a suggestion than anything else. Reuses code of
namedQueryDocument and namedMutationDocument for queryDocument and
mutationDocument respectively.

Downside, with this change, namedMutationDocument and namedQueryDocument
must wrap the supplied name in a Just.
Upside, all Document creation goes through the same code.